### PR TITLE
Use only field's attname for state tracking

### DIFF
--- a/django_model_changes/changes.py
+++ b/django_model_changes/changes.py
@@ -104,7 +104,6 @@ class ChangesMixin(object):
         Returns a ``field -> value`` dict of the current state of the instance.
         """
         field_names = set()
-        [field_names.add(f.name) for f in self._state_fields()]
         [field_names.add(f.attname) for f in self._state_fields()]
         return dict([(field_name, getattr(self, field_name, None)) for field_name in field_names])
 

--- a/django_model_changes/changes.py
+++ b/django_model_changes/changes.py
@@ -77,7 +77,7 @@ class ChangesMixin(object):
         )
 
     def _state_fields(self):
-        return [f for f in self._meta.get_fields() if f.concrete and not f.is_relation]
+        return [f for f in self._meta.get_fields() if f.concrete and not f.many_to_many]
 
     def _save_state(self, new_instance=False, event_type=None, created=False):
         # Pipe the pk on deletes so that a correct snapshot of the current

--- a/django_model_changes/changes.py
+++ b/django_model_changes/changes.py
@@ -77,7 +77,7 @@ class ChangesMixin(object):
         )
 
     def _state_fields(self):
-        return [f for f in self._meta.get_fields() if f.concrete and not f.many_to_many]
+        return [f for f in self._meta.get_fields() if f.concrete and not f.is_relation]
 
     def _save_state(self, new_instance=False, event_type=None, created=False):
         # Pipe the pk on deletes so that a correct snapshot of the current

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-model-changes',
-    version='0.15',
+    version='0.16',
     packages=find_packages(exclude=['tests']),
     license='MIT License',
     description='django-model-changes allows you to track model instance changes.',


### PR DESCRIPTION
Problem
---
Entities' related entities (e.g. 1:1, M:1) can be accessed by calling `obj.related_entity`, which populates the related entity (which executes additional SQL queries), or by calling `obj.related_entity_id` containing only the ID.

Originally, this library accessed both fields. Tracking only the IDs of the related entities may be sufficient.

Solution
---
Do not use the field's `name` which populates related entities. Use only the `attname` of the field which only contains the ID of the related entity.

After this gets merged, a new version should be tagged, and `requirements.txt` in should be updated with the new version.